### PR TITLE
fs/source: Fix List infinite retry

### DIFF
--- a/endpoint/fs/source.go
+++ b/endpoint/fs/source.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/yunify/qscamel/constants"
 	"github.com/yunify/qscamel/model"
@@ -11,15 +14,24 @@ import (
 )
 
 // List implement source.List
+// errors in List may be ignored (depend on isIgnoredErr()), to avoid infinite backoff
 func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o model.Object)) (err error) {
 	cp := filepath.Join(c.AbsPath, j.Key)
 
 	fi, err := os.Open(cp)
 	if err != nil {
-		return
+		logrus.Warnf("open <%s> failed: [%v]", cp, err)
+		return err
 	}
 	list, err := fi.Readdir(-1)
 	fi.Close()
+	if err != nil {
+		if isIgnoredErr(err) {
+			logrus.Warnf("read dir <%s> failed: [%v], ignored", fi.Name(), err)
+			return nil
+		}
+		return err
+	}
 
 	for _, v := range list {
 		// if v is a link, and client not follow link, skip it
@@ -29,6 +41,10 @@ func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o m
 
 		target, err := checkLink(v, cp)
 		if err != nil {
+			if isIgnoredErr(err) {
+				logrus.Warnf("check link for <%s> failed: [%v], skipped", v.Name(), err)
+				continue
+			}
 			return err
 		}
 
@@ -41,6 +57,14 @@ func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o m
 
 			continue
 		}
+
+		// Skip irregular file, such as: device, io pipe, etc.
+		if !target.Mode().IsRegular() {
+			logrus.Infof("target <%s> skipped because its not a regular file",
+				"/"+utils.Join(cp, v.Name()))
+			continue
+		}
+
 		o := &model.SingleObject{
 			Key:  "/" + utils.Join(j.Key, v.Name()), // always use current v's name as key
 			Size: target.Size(),
@@ -75,4 +99,12 @@ func checkLink(v os.FileInfo, cp string) (os.FileInfo, error) {
 		return nil, err
 	}
 	return os.Stat(tarPath)
+}
+
+// isIgnoredErr try to check whether an error should be ignored, which will lead to not retry List()
+func isIgnoredErr(err error) bool {
+	if strings.Contains(err.Error(), "bad file descriptor") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
* Ignore errors (which cannot be solved by retry) in List
* Skip irregular files (such as named pipe, socket, device file, character device file and other unknonw non-regular file)