### PR TITLE
endpoint/qingstor: Fix bug with wrong path when head object

### DIFF
--- a/endpoint/qingstor/source.go
+++ b/endpoint/qingstor/source.go
@@ -35,7 +35,7 @@ func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o m
 		for _, v := range resp.Keys {
 			if strings.HasSuffix(*v.Key, "/") {
 				key := utils.Relative(*v.Key, c.Path) + "/"
-				output, err := c.client.HeadObject(key, nil)
+				output, err := c.client.HeadObject(*v.Key, nil)
 				if err == nil {
 					so := &model.SingleObject{
 						Key:          key,
@@ -53,7 +53,7 @@ func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o m
 			}
 
 			key := utils.Relative(*v.Key, c.Path)
-			output, err := c.client.HeadObject(key, nil)
+			output, err := c.client.HeadObject(*v.Key, nil)
 			if err == nil {
 				object := &model.SingleObject{
 					Key:          key,


### PR DESCRIPTION
endpoint/qingstor: Fix bug with wrong path when head object

In #320 , after qingstor serves list objects, the key used for head object is a relative path, which is wrong.
This operation requires the full path to be uploaded.

This commit fixes the bug.