### PR TITLE
endpoint/fs: Add last modified time to the source endpoint

### DIFF
--- a/endpoint/fs/source.go
+++ b/endpoint/fs/source.go
@@ -66,8 +66,9 @@ func (c *Client) List(ctx context.Context, j *model.DirectoryObject, fn func(o m
 		}
 
 		o := &model.SingleObject{
-			Key:  "/" + utils.Join(j.Key, v.Name()), // always use current v's name as key
-			Size: target.Size(),
+			Key:          "/" + utils.Join(j.Key, v.Name()), // always use current v's name as key
+			Size:         target.Size(),
+			LastModified: target.ModTime().Unix(),
 		}
 
 		fn(o)


### PR DESCRIPTION
Added support for skipping last modified object for fs endpoint.

The ignore_existing flag is not supported when the fs endpoint is included in the migration because the last modified data of the file is not taken when the local file is fetched.