### PR TITLE
feat: Added MD5 check after migration

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -25,6 +25,7 @@ type Task struct {
 	Src *Endpoint `yaml:"source" msgpack:"src"`
 	Dst *Endpoint `yaml:"destination" msgpack:"dst"`
 
+	CheckMD5              bool   `yaml:"check_md5" msgpack:"cm"`
 	IgnoreExisting        string `yaml:"ignore_existing" msgpack:"ie"`
 	MultipartBoundarySize int64  `yaml:"multipart_boundary_size" msgpack:"mbs"`
 	// Format: 2006-01-02 15:04:05


### PR DESCRIPTION
Added MD5 check after migration

The global configuration file has the following additions:

```
type: copy

check_md5: ture # Added global configuration, default is false

source:
  type: filelist
  path: /path/to/source
  options:
    list_path: /path/to/list

destination:
  type: qingstor
  path: /path/to/destination
  options:
    protocol: https
    host: qsstor.com
    port: 443
    bucket_name: example_bucket
    access_key_id: example_access_key_id
    secret_access_key: example_secret_access_key
```