### PR TITLE
Bump to version 2.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to QingStor qscamel will be documented in this file.
 
+## [v2.0.27] - 2025-09-09
+
+### Fixed
+
+- fix: Comment out the size check before migration (#347)
+
 ## [v2.0.26] - 2025-08-05
 
 ### Added
@@ -248,6 +254,7 @@ All notable changes to QingStor qscamel will be documented in this file.
 
 - QingStor qscamel.
 
+[v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.26...v2.0.27
 [v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.25...v2.0.26
 [v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.24...v2.0.25
 [v2.0.24]: https://github.com/yunify/qscamel/compare/v2.0.23...v2.0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,8 +254,8 @@ All notable changes to QingStor qscamel will be documented in this file.
 
 - QingStor qscamel.
 
-[v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.26...v2.0.27
-[v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.25...v2.0.26
+[v2.0.27]: https://github.com/yunify/qscamel/compare/v2.0.26...v2.0.27
+[v2.0.26]: https://github.com/yunify/qscamel/compare/v2.0.25...v2.0.26
 [v2.0.25]: https://github.com/yunify/qscamel/compare/v2.0.24...v2.0.25
 [v2.0.24]: https://github.com/yunify/qscamel/compare/v2.0.23...v2.0.24
 [v2.0.23]: https://github.com/yunify/qscamel/compare/v2.0.22...v2.0.23

--- a/constants/version.go
+++ b/constants/version.go
@@ -17,4 +17,4 @@
 package constants
 
 // Version number string.
-const Version = "2.0.26"
+const Version = "2.0.27"


### PR DESCRIPTION
## [v2.0.27] - 2025-09-09

### Fixed

- fix: Comment out the size check before migration (#347)